### PR TITLE
alpine: Add support for armv7 Alpine Linux

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -25,8 +25,8 @@ do
 			sed -e s~#{FROM}~balenalib/i386-debian:jessie~g \
 				-e s~#{QEMU}~""~g Dockerfile.debian.tpl > Dockerfile
 		;;
-		'alpine-armhf')
-			sed -e s~#{FROM}~balenalib/armv7hf-alpine:3.6~g \
+		'alpine-armv6hf')
+			sed -e s~#{FROM}~balenalib/rpi-alpine:3.6~g \
 				-e s~#{QEMU}~"COPY qemu/qemu-arm-static /usr/bin/"~g Dockerfile.alpine.tpl > Dockerfile
 		;;
 		'alpine-i386')
@@ -40,6 +40,11 @@ do
 		'alpine-aarch64')
 			sed -e s~#{FROM}~balenalib/aarch64-alpine:3.6~g \
 				-e s~#{QEMU}~"COPY qemu/qemu-aarch64-static /usr/bin/"~g Dockerfile.alpine.tpl > Dockerfile
+		;;
+		'alpine-armv7hf')
+			# armv7hf-alpine v3.9 and later are armv7
+			sed -e s~#{FROM}~balenalib/armv7hf-alpine:3.9~g \
+				-e s~#{QEMU}~"COPY qemu/qemu-arm-static /usr/bin/"~g Dockerfile.alpine.tpl > Dockerfile
 		;;
 	esac
 	docker build -t go-$ARCH-builder .

--- a/build.sh
+++ b/build.sh
@@ -21,10 +21,10 @@ rm go-linux-$ARCH-bootstrap.tbz
 export GOROOT_BOOTSTRAP=/go-bootstrap
 
 case "$ARCH" in
-	'armv6hf')
+	'armv6hf'|'alpine-armv6hf')
 		export GOARM=6
 	;;
-	'armv7hf')
+	'armv7hf'|'alpine-armv7hf')
 		export GOARM=7
 	;;
 	'armel')
@@ -32,9 +32,6 @@ case "$ARCH" in
 	;;
 	'aarch64'|'alpine-aarch64')
 		export GOARCH=arm64
-	;;
-	'alpine-armhf')
-		export GOARM=7
 	;;
 	'alpine-i386')
 		export GOARCH=386


### PR DESCRIPTION
Since armv7 Alpine Linux is released, the build script is updated to support this architecture

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>